### PR TITLE
fix(notification): @Param import 수정 및 JPQL 문법 오류 수정

### DIFF
--- a/src/main/java/com/moru/backend/domain/notification/dao/NotificationRepository.java
+++ b/src/main/java/com/moru/backend/domain/notification/dao/NotificationRepository.java
@@ -1,7 +1,7 @@
 package com.moru.backend.domain.notification.dao;
 
 import com.moru.backend.domain.notification.domain.Notification;
-import io.lettuce.core.dynamic.annotation.Param;
+import org.springframework.data.repository.query.Param;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -17,7 +17,7 @@ public interface NotificationRepository extends JpaRepository<Notification, UUID
             AND (
                 :lastCreatedAt IS NULL OR
                 n.createdAt < :lastCreatedAt OR
-                (n.createdAt = :lastCreatedAt AND n.id <: lastNotificationId)
+                (n.createdAt = :lastCreatedAt AND n.id < :lastNotificationId)
             )
         ORDER BY n.createdAt DESC, n.id DESC
     """)


### PR DESCRIPTION
- 잘못된 @Param import(io.lettuce...)를 Spring Data JPA용으로 교체
- JPQL 문법 오류 (<:)를 (< :)로 수정
- lastNotificationId 파라미터 정상 바인딩되도록 변경

## #️⃣ Issue Number



## 📝 요약(Summary)



## 📸 스크린샷 (선택)



## 💬리뷰 요구사항(선택)



