### PR TITLE
Bugfix/#120 like count

### DIFF
--- a/src/main/java/com/moru/backend/global/dummydata/DummyDataGenerator.java
+++ b/src/main/java/com/moru/backend/global/dummydata/DummyDataGenerator.java
@@ -198,7 +198,7 @@ public class DummyDataGenerator {
                     .content(content)
                     .isSimple(isSimpleRoutine)
                     .isUserVisible(random.nextBoolean())
-                    .likeCount(random.nextInt(500))
+                    .likeCount(0)
                     .viewCount(random.nextInt(2000))
                     // requiredTime은 아래에서 스텝 시간 합계로 계산되므로 여기서는 설정하지 않음
                     .imageUrl(random.nextInt(10) < 3 ? faker.avatar().image() : null) // 30% 확률로 이미지 URL 추가

--- a/src/main/java/com/moru/backend/global/dummydata/DummyDataInitializer.java
+++ b/src/main/java/com/moru/backend/global/dummydata/DummyDataInitializer.java
@@ -21,6 +21,7 @@ public class DummyDataInitializer implements CommandLineRunner {
     // 직접 호출할 서비스 클래스
     private final DummyDataGenerator dummyDataGenerator;
     private final DummyDataProperties dummyDataProperties;
+    private final RoutineLikeSeeder routineLikeSeeder;
 
     @Override
     public void run(String... args) throws Exception {
@@ -42,8 +43,10 @@ public class DummyDataInitializer implements CommandLineRunner {
         log.info("[3/8] {}명의 사용자를 생성했습니다.", allUsers.size());
 
         List<Routine> allRoutines = dummyDataGenerator.createBulkRoutines(dummyDataProperties.getRoutineCount(), allUsers, allTags, allApps);
+        routineLikeSeeder.seedLikesForRoutines(allRoutines, allUsers);
+        
         log.info("[4/8] {}개의 루틴과 관련 데이터(스텝, 태그연결, 스케줄)를 생성했습니다.", allRoutines.size());
-
+        
 //        dummyDataGenerator.createBulkRelationsAndLogs(dummyDataProperties.getRelationCount(), allUsers, allTags, allRoutines);
 //        log.info("[5/5] 팔로우, 선호 태그, 루틴 로그 데이터를 생성했습니다.");
         List<UserFollow> allFollows = dummyDataGenerator.createFollowRelations(dummyDataProperties.getFollowCount(), allUsers);

--- a/src/main/java/com/moru/backend/global/dummydata/RoutineLikeSeeder.java
+++ b/src/main/java/com/moru/backend/global/dummydata/RoutineLikeSeeder.java
@@ -1,0 +1,86 @@
+package com.moru.backend.global.dummydata;
+
+import com.moru.backend.domain.routine.domain.ActionType;
+import com.moru.backend.domain.routine.domain.Routine;
+import com.moru.backend.domain.social.dao.RoutineUserActionRepository;
+import com.moru.backend.domain.social.domain.RoutineUserAction;
+import com.moru.backend.domain.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.*;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+
+public class RoutineLikeSeeder {
+    private static final int ACTION_BATCH_SIZE = 200; // 액션 배치 크기 (상황에 맞게 조절)
+    private static final int MAX_LIKES_PER_ROUTINE = 50;
+
+    private final RoutineUserActionRepository routineUserActionRepository;
+
+    /**
+     * 새로 만든 루틴들에 대해 0~{MAX_LIKES_PER_ROUTINE}개의 LIKE 액션을 랜덤 생성하고,
+     * 각 루틴의 likeCount를 실제 생성 개수로 맞춘다.
+     *
+     * @param routines createBulkRoutines에서 방금 저장/리턴한 루틴 리스트
+     * @return 생성된 RoutineUserAction 총 개수
+     */
+
+    @Transactional
+    public void seedLikesForRoutines(List<Routine> routines, List<User> allUsers) {
+        if(routines == null || routines.isEmpty()) return;
+        if(allUsers == null || allUsers.isEmpty()) return;
+
+        Random rnd = new Random();
+
+        List<RoutineUserAction> actionBatch = new ArrayList<>(ACTION_BATCH_SIZE);
+
+        for(Routine routine : routines) {
+            UUID routineId = routine.getId();
+            if (routineId == null) continue;
+
+            // 0 - Min(100, 유저수)
+            int maxLikes = Math.min(MAX_LIKES_PER_ROUTINE, allUsers.size());
+            int likeCount = rnd.nextInt(maxLikes+ 1);
+            if(likeCount == 0) {
+                continue;
+            }
+
+            // 루틴 내 중복 방지: 유저 리스트 섞고 앞에서 likeCount명 사용 (중복 없음)
+            List<User> shuffled = new ArrayList<>(allUsers);
+            Collections.shuffle(shuffled, rnd);
+            List<User> picked = shuffled.subList(0, likeCount);
+
+            for (User u : picked) {
+                RoutineUserAction action = RoutineUserAction.builder()
+                        .routine(routine)
+                        .user(u)
+                        .actionType(ActionType.LIKE)
+                        .createdAt(LocalDateTime.now())
+                        .createdAt(LocalDateTime.now())
+                        .build();
+                actionBatch.add(action);
+
+                if (actionBatch.size() >= ACTION_BATCH_SIZE) {
+                    routineUserActionRepository.saveAll(actionBatch);
+                    actionBatch.clear();
+                }
+            }
+
+            // 루틴의 likeCount를 실제 생성량으로 동기화
+            routine.setLikeCount(likeCount);
+        }
+
+        if (!actionBatch.isEmpty()) {
+            routineUserActionRepository.saveAll(actionBatch);
+        }
+
+        log.info("LIKE seeding done for {} routines.", routines.size());
+    }
+
+}


### PR DESCRIPTION
## #️⃣ Issue Number

#120

## 📝 요약(Summary)

기존에 무작위로 루틴 객체의 likeCount만 숫자 값을 저장하고 실제 RoutineUserAction에는 생성하지 않아 데이터 일관성이 깨지는 문제를 해결하였다.

루틴을 돌며 0-{최대 좋아요 수}개 사이의 랜덤한 수로 RoutineUserAction(LIKE)를 생성하여 일관성을 보존했다.

클래스를 따로 분리하여 가시성을 높였다.

## 📸 스크린샷 (선택)



## 💬리뷰 요구사항(선택)



