### PR TITLE
Bugfix/#124 routine log detail

### DIFF
--- a/src/main/java/com/moru/backend/domain/log/dao/RoutineLogRepository.java
+++ b/src/main/java/com/moru/backend/domain/log/dao/RoutineLogRepository.java
@@ -15,23 +15,16 @@ public interface RoutineLogRepository extends JpaRepository<RoutineLog, UUID> {
     @Query("""
         SELECT rl FROM RoutineLog rl
         JOIN FETCH rl.routineSnapshot snap
-        LEFT JOIN FETCH snap.tagSnapshots
-        LEFT JOIN FETCH snap.appSnapshots
-        LEFT JOIN FETCH snap.stepSnapshots
-        LEFT JOIN FETCH rl.routineStepLogs stepLog
-        LEFT JOIN FETCH stepLog.routineStep
         WHERE rl.id = :logId
     """)
-    Optional<RoutineLog> findByRoutineLogIdWithSnapshotAndSteps(UUID logId);
+    Optional<RoutineLog> findByRoutineLogIdWithSnapshot(UUID logId);
 
     @Query("""
-        SELECT rl FROM RoutineLog rl
-        JOIN FETCH rl.routineSnapshot snap
-        LEFT JOIN FETCH snap.tagSnapshots
-        WHERE rl.user.id = :userId
-        ORDER BY rl.startedAt DESC
+        SELECT DISTINCT rl FROM RoutineLog rl
+        LEFT JOIN FETCH rl.routineStepLogs steplog
+        WHERE rl.id = :logId
     """)
-    List<RoutineLog> findAllByUserIdWithSnapshot(UUID userId);
+    Optional<RoutineLog> fetchStepLogs(UUID logId);
 
     List<RoutineLog> findByUserIdAndStartedAtBetween(UUID userId, LocalDateTime start, LocalDateTime end);
 

--- a/src/main/java/com/moru/backend/domain/log/dao/RoutineSnapshotRepository.java
+++ b/src/main/java/com/moru/backend/domain/log/dao/RoutineSnapshotRepository.java
@@ -2,6 +2,33 @@ package com.moru.backend.domain.log.dao;
 
 import com.moru.backend.domain.log.domain.snapshot.RoutineSnapshot;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
+import java.util.UUID;
 
 public interface RoutineSnapshotRepository extends JpaRepository<RoutineSnapshot, Long> {
+    // [추가] 스텝 스냅샷만
+    @Query("""
+        SELECT s FROM RoutineSnapshot s
+        LEFT JOIN FETCH s.stepSnapshots
+        WHERE s.id = :snapshotId
+    """)
+    Optional<RoutineSnapshot> fetchStepSnapshots(UUID snapshotId);
+
+    // [추가] 앱 스냅샷만
+    @Query("""
+        SELECT s FROM RoutineSnapshot s
+        LEFT JOIN FETCH s.appSnapshots
+        WHERE s.id = :snapshotId
+    """)
+    Optional<RoutineSnapshot> fetchAppSnapshots(UUID snapshotId);
+
+    // [추가] 태그 스냅샷만 (필요할 때만 호출)
+    @Query("""
+        SELECT s FROM RoutineSnapshot s
+        LEFT JOIN FETCH s.tagSnapshots
+        WHERE s.id = :snapshotId
+    """)
+    Optional<RoutineSnapshot> fetchTagSnapshots(UUID snapshotId);
 }


### PR DESCRIPTION
## #️⃣ Issue Number

#124

## 📝 요약(Summary)

### 배경 / 문제
- RoutineLog 상세 조회에서 한 쿼리로 tagSnapshots, appSnapshots, stepSnapshots, routineStepLogs를 모두 fetch-join 하며 Hibernate의 MultipleBagFetchException이 발생했습니다.

### 해결 전략

- 한 쿼리당 bag ≤ 1 원칙으로 조회를 단계적 로딩으로 분리
- 루트 + to-one만 먼저 로드 → 하위 컬렉션을 개별 쿼리로 초기화
- 스텝 로그는 별도 로딩(SELECT DISTINCT)으로 중복/카테시안 방지
- 잘못된 nested 조인 제거

### 파일별 변경사항
- RoutineLogRepository.java
  - findByRoutineLogIdWithSnapshot(UUID) 추가(루트 + 스냅샷만)
  - fetchStepLogs(UUID) 추가(DISTINCT 적용)
  - 대형 fetch-join 쿼리 삭제 및 잘못된 조인 제거
- RoutineLogService.java
  - getRoutineLogDetail에서 단계적 초기화 적용(스냅샷·앱·태그·스텝 로그 순)
  - 응답 DTO/스키마 변화 없음
- RoutineSnapshotRepository.java
  - fetchStepSnapshots, fetchAppSnapshots, fetchTagSnapshots 추가

## 📸 스크린샷 (선택)



## 💬리뷰 요구사항(선택)

이번 변경으로 인해 다음과 같은 영향이 발생합니다. 배치 페치 설정을 해주실 수 있을까요? 배포를 제가 한게 아니라 yml 파일 건드리기 조심스럽습니다.

### 영향 범위
- RoutineLog 상세 조회 안정화 (예외 제거)
- N+1 가능성은 있으나 쿼리는 단순해지고, 배치 페치 설정으로 완화 가능
- (예: hibernate.default_batch_fetch_size: 100 또는 필드단 @BatchSize)



