### PR TITLE
Bugfix/#127 routine delete

### DIFF
--- a/src/main/java/com/moru/backend/domain/routine/domain/schedule/RoutineScheduleHistory.java
+++ b/src/main/java/com/moru/backend/domain/routine/domain/schedule/RoutineScheduleHistory.java
@@ -7,13 +7,13 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
-
-import com.moru.backend.domain.routine.domain.schedule.DayOfWeek;
 
 @Entity
 @EntityListeners(AuditingEntityListener.class)
@@ -35,11 +35,13 @@ public class RoutineScheduleHistory {
     // 어떤 루틴의 스케줄 히스토리인지
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "routine_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Routine routine;
 
     // 유효 요일
     @ElementCollection(fetch = FetchType.EAGER)
     @CollectionTable(name = "routine_schedule_history_days", joinColumns = @JoinColumn(name = "history_id"))
+    @OnDelete(action = OnDeleteAction.CASCADE)
     @Enumerated(EnumType.STRING)
     @Column(name = "day_of_week")
     private List<DayOfWeek> scheduledDays;

--- a/src/main/java/com/moru/backend/domain/social/domain/RoutineUserAction.java
+++ b/src/main/java/com/moru/backend/domain/social/domain/RoutineUserAction.java
@@ -9,6 +9,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -42,6 +44,7 @@ public class RoutineUserAction {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "routine_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Routine routine;
 
     @Enumerated(EnumType.STRING)


### PR DESCRIPTION
## #️⃣ Issue Number

#127

## 📝 요약(Summary)

루틴 삭제 시 실패하는 문제를 해결한 PR입니다.

### 배경 / 문제
- DELETE FROM routine WHERE id=? 수행 시 DB에서 FK 제약 오류가 발생했습니다.
- 연관 테이블이 ON DELETE CASCADE 미설정 상태였고, 애플리케이션에서 부모(routine)을 먼저 삭제하게 되면서 자식 레코드가 남아 FK 위반이 발생하였습니다.

### 해결 전략
- DB 레벨에서 일관된 삭제 규칙을 보장하기 위해 루틴이 삭제되면 모든 자식 행이 함께 삭제되도록 FK를 `ON DELETE CASCADE`를 추가였습니다. (엔티티에 힌트 추가 후 더미데이터 재생성하여 추가함)
- 엔티티 수준 힌트 정렬: Hibernate의 `@OnDelete(OnDeleteAction.CASCADE)`를 추가해 스키마 생성 시점 및 문서화 관점에서 의도를 명확히 하였습니다.
- 애플리케이션 서비스 로직은 수정하지 않았습니다.

### 파일별 변경사항
- RoutineScheduleHistory.java
  - 추가: @OnDelete(action = OnDeleteAction.CASCADE)
    - @ManyToOne Routine routine에 적용 → routine 삭제 시 해당 히스토리 일괄 삭제 의도 명시
    - @ElementCollection scheduledDays의 @CollectionTable에도 적용 → 히스토리 삭제 시 days 행 동반 삭제 의도 명시
  - 코멘트/정렬 등 경미한 클린업
- RoutineUserAction.java
  -  추가: @OnDelete(action = OnDeleteAction.CASCADE)
@ManyToOne Routine routine에 적용 → 루틴 삭제 시 사용자 액션(좋아요/스크랩)도 함께 삭제되도록 의도 명시


## 📸 스크린샷 (선택)



## 💬리뷰 요구사항(선택)



