### PR TITLE
Fix/#110 fe routine api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	compileOnly 'org.projectlombok:lombok:1.18.30'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/src/main/java/com/moru/backend/domain/routine/dao/routine/RoutineRepository.java
+++ b/src/main/java/com/moru/backend/domain/routine/dao/routine/RoutineRepository.java
@@ -73,7 +73,7 @@ public interface RoutineRepository extends JpaRepository<Routine, UUID>, Routine
      * @return 조건에 맞는 루틴의 페이징된 목록
      */
 
-    // 최신순
+    // 최신순 (요일 선택)
     @Query(value = """
     SELECT DISTINCT r
       FROM Routine r
@@ -96,8 +96,11 @@ public interface RoutineRepository extends JpaRepository<Routine, UUID>, Routine
             @Param("dayOfWeek") DayOfWeek dayOfWeek,
             Pageable pageable
     );
+    // 최신순 (요일 미선택)
+    Page<Routine> findDistinctByUserIdAndStatusIsTrueOrderByCreatedAtDesc(
+            UUID userId, Pageable pageable);
 
-    // 인기순
+    // 인기순 (요일 선택)
     @Query(value = """
     SELECT DISTINCT r
       FROM Routine r
@@ -120,6 +123,9 @@ public interface RoutineRepository extends JpaRepository<Routine, UUID>, Routine
             @Param("dayOfWeek") DayOfWeek dayOfWeek,
             Pageable pageable
     );
+    // 인기순 (요일 미선택)
+    Page<Routine> findDistinctByUserIdAndStatusIsTrueOrderByLikeCountDescCreatedAtDesc(
+            UUID userId, Pageable pageable);
 
     // 시간순
     @Query(value = "SELECT DISTINCT r FROM Routine r JOIN r.routineSchedules s WHERE r.user.id = :userId AND r.status = true AND s.dayOfWeek = :dayOfWeek ORDER BY s.time ASC",

--- a/src/main/java/com/moru/backend/domain/routine/dao/routine/RoutineRepository.java
+++ b/src/main/java/com/moru/backend/domain/routine/dao/routine/RoutineRepository.java
@@ -96,21 +96,22 @@ public interface RoutineRepository extends JpaRepository<Routine, UUID>, Routine
      * @param pageable   결과 개수 제한
      * @return 인기 루틴 목록
      */
-    @Query(value = "SELECT r.id FROM Routine r WHERE r.createdAt >= :weekAgo " +
+    @Query(value = "SELECT r.id FROM Routine r WHERE r.createdAt >= :weekAgo AND r.user.id <> :userId " +
             "GROUP BY r.id, r.viewCount, r.likeCount, r.createdAt " + // GROUP BY에 정렬 기준 컬럼 추가
             "ORDER BY (CAST(r.viewCount AS double) * :viewWeight + CAST(r.likeCount AS double) * :likeWeight) DESC, r.createdAt DESC")
     List<UUID> findHotRoutinesIds(@Param("weekAgo") LocalDateTime weekAgo,
                                   @Param("viewWeight") double viewWeight,
                                   @Param("likeWeight") double likeWeight,
+                                  @Param("userId") UUID userId,
                                   Pageable pageable);
 
     /**
      * 주어진 태그를 포함하는 루틴의 ID를, 태그 일치 개수가 많은 순으로 정렬하여 조회.
      * JOIN FETCH를 제거하여 COUNT 및 GROUP BY와 함께 사용할 수 있도록 수정했.
      */
-    @Query(value = "SELECT r.id FROM Routine r JOIN r.routineTags rt WHERE rt.tag.name IN :tags GROUP BY r.id ORDER BY COUNT(r.id) DESC, r.createdAt DESC",
-            countQuery = "SELECT COUNT(DISTINCT r.id) FROM Routine r JOIN r.routineTags rt WHERE rt.tag.name IN :tags")
-    Page<UUID> findRoutineIdsByTagsOrderByTagCount(@Param("tags") List<String> tags, Pageable pageable);
+    @Query(value = "SELECT r.id FROM Routine r JOIN r.routineTags rt WHERE rt.tag.name IN :tags AND r.user.id <> :userId GROUP BY r.id ORDER BY COUNT(r.id) DESC, r.createdAt DESC",
+            countQuery = "SELECT COUNT(DISTINCT r.id) FROM Routine r JOIN r.routineTags rt WHERE rt.tag.name IN :tags AND r.user.id <> :userId")
+    Page<UUID> findRoutineIdsByTagsOrderByTagCount(@Param("tags") List<String> tags, @Param("userId") UUID userId, Pageable pageable);
 
     @Query("""
         SELECT r FROM Routine r
@@ -133,11 +134,11 @@ public interface RoutineRepository extends JpaRepository<Routine, UUID>, Routine
         SELECT r.id FROM Routine r
         JOIN r.routineTags rt1
         JOIN r.routineTags rt2
-        WHERE rt1.tag.id = :tag1 AND rt2.tag.id = :tag2
+        WHERE rt1.tag.id = :tag1 AND rt2.tag.id = :tag2 AND r.user.id <> :userId
         GROUP BY r.id
         ORDER BY (CAST(r.viewCount AS double) * 0.5 + CAST(r.likeCount AS double) * 0.5) DESC, r.createdAt DESC
-    """, countQuery = "SELECT COUNT(DISTINCT r.id) FROM Routine r JOIN r.routineTags rt1 JOIN r.routineTags rt2 WHERE rt1.tag.id = :tag1 AND rt2.tag.id = :tag2")
-    Page<UUID> findRoutineIdsByTagPair(@Param("tag1") UUID tag1, @Param("tag2") UUID tag2, Pageable pageable);
+    """, countQuery = "SELECT COUNT(DISTINCT r.id) FROM Routine r JOIN r.routineTags rt1 JOIN r.routineTags rt2 WHERE rt1.tag.id = :tag1 AND rt2.tag.id = :tag2 AND r.user.id <> :userId")
+    Page<UUID> findRoutineIdsByTagPair(@Param("tag1") UUID tag1, @Param("tag2") UUID tag2, @Param("userId") UUID userId, Pageable pageable);
 
     /**
      * 특정 루틴의 조회수를 1 증가시킵니다.

--- a/src/main/java/com/moru/backend/domain/routine/dao/routine/RoutineRepository.java
+++ b/src/main/java/com/moru/backend/domain/routine/dao/routine/RoutineRepository.java
@@ -74,15 +74,60 @@ public interface RoutineRepository extends JpaRepository<Routine, UUID>, Routine
      */
 
     // 최신순
-    Page<Routine> findDistinctByUserAndStatusIsTrueOrderByCreatedAtDesc(User user, Pageable pageable);
+    @Query(value = """
+    SELECT DISTINCT r
+      FROM Routine r
+      JOIN r.routineSchedules s
+     WHERE r.user.id = :userId
+       AND r.status = true
+       AND s.dayOfWeek = :dayOfWeek
+  ORDER BY r.createdAt DESC
+""",
+            countQuery = """
+    SELECT COUNT(DISTINCT r.id)
+      FROM Routine r
+      JOIN r.routineSchedules s
+     WHERE r.user.id = :userId
+       AND r.status = true
+       AND s.dayOfWeek = :dayOfWeek
+""")
+    Page<Routine> findRoutinesByUserIdAndDayOfWeekOrderByCreatedAtDesc(
+            @Param("userId") UUID userId,
+            @Param("dayOfWeek") DayOfWeek dayOfWeek,
+            Pageable pageable
+    );
 
     // 인기순
-    Page<Routine> findDistinctByUserAndStatusIsTrueOrderByLikeCountDescCreatedAtDesc(User user, Pageable pageable);
+    @Query(value = """
+    SELECT DISTINCT r
+      FROM Routine r
+      JOIN r.routineSchedules s
+     WHERE r.user.id = :userId
+       AND r.status = true
+       AND s.dayOfWeek = :dayOfWeek
+  ORDER BY r.likeCount DESC, r.createdAt DESC
+""",
+            countQuery = """
+    SELECT COUNT(DISTINCT r.id)
+      FROM Routine r
+      JOIN r.routineSchedules s
+     WHERE r.user.id = :userId
+       AND r.status = true
+       AND s.dayOfWeek = :dayOfWeek
+""")
+    Page<Routine> findRoutinesByUserIdAndDayOfWeekOrderByPopularity(
+            @Param("userId") UUID userId,
+            @Param("dayOfWeek") DayOfWeek dayOfWeek,
+            Pageable pageable
+    );
 
-    // 시간순 (특정 요일)
+    // 시간순
     @Query(value = "SELECT DISTINCT r FROM Routine r JOIN r.routineSchedules s WHERE r.user.id = :userId AND r.status = true AND s.dayOfWeek = :dayOfWeek ORDER BY s.time ASC",
             countQuery = "SELECT COUNT(DISTINCT r.id) FROM Routine r JOIN r.routineSchedules s WHERE r.user.id = :userId AND r.status = true AND s.dayOfWeek = :dayOfWeek")
-    Page<Routine> findRoutinesByUserIdAndDayOfWeekOrderByScheduleTimeAsc(@Param("userId") UUID userId, @Param("dayOfWeek") DayOfWeek dayOfWeek, Pageable pageable);
+    Page<Routine> findRoutinesByUserIdAndDayOfWeekOrderByScheduleTimeAsc(
+            @Param("userId") UUID userId,
+            @Param("dayOfWeek") DayOfWeek dayOfWeek,
+            Pageable pageable);
 
     List<Routine> findAllByUserId(UUID userId);
 

--- a/src/main/java/com/moru/backend/global/dummydata/seeder/RoutineLogSeeder.java
+++ b/src/main/java/com/moru/backend/global/dummydata/seeder/RoutineLogSeeder.java
@@ -204,6 +204,7 @@ public class RoutineLogSeeder {
             List<RoutineSnapshot> savedSnapshots,
             List<User> users,
             Map<UUID, User> routineOwnerMap,
+            Map<UUID, Set<DayOfWeek>> scheduleByRoutine,
             Set<UUID> usersWithOpenLog,
             Map<UUID, LocalDateTime> openLogStartByUser
     ) {
@@ -220,7 +221,9 @@ public class RoutineLogSeeder {
             User owner = routineOwnerMap.getOrDefault(
                     snapshot.getOriginalRoutineId(),
                     users.get(random.nextInt(users.size()))); // 혹시 못찾으면 랜덤 유저
-            logsToSave.add(buildRoutineLog(snapshot, owner, usersWithOpenLog, openLogStartByUser));
+
+            Set<DayOfWeek> scheduleDays = scheduleByRoutine.getOrDefault(snapshot.getOriginalRoutineId(), Set.of());
+            logsToSave.add(buildRoutineLog(snapshot, owner, scheduleDays, usersWithOpenLog, openLogStartByUser));
         }
         batchSaveLogs(logsToSave);
     }

--- a/src/main/java/com/moru/backend/global/dummydata/seeder/RoutineLogSeeder.java
+++ b/src/main/java/com/moru/backend/global/dummydata/seeder/RoutineLogSeeder.java
@@ -8,14 +8,14 @@ import com.moru.backend.domain.log.domain.snapshot.RoutineSnapshot;
 import com.moru.backend.domain.log.domain.snapshot.RoutineStepSnapshot;
 import com.moru.backend.domain.log.domain.snapshot.RoutineTagSnapshot;
 import com.moru.backend.domain.routine.domain.Routine;
+import com.moru.backend.domain.routine.domain.schedule.RoutineSchedule;
 import com.moru.backend.domain.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.Duration;
-import java.time.LocalDateTime;
+import java.time.*;
 import java.util.*;
 import java.util.stream.Collectors;
 

--- a/src/main/java/com/moru/backend/global/dummydata/seeder/RoutineLogSeeder.java
+++ b/src/main/java/com/moru/backend/global/dummydata/seeder/RoutineLogSeeder.java
@@ -54,6 +54,10 @@ public class RoutineLogSeeder {
         Map<UUID, User> routineOwnerMap = routines.stream()
                 .collect(Collectors.toMap(Routine::getId, Routine::getUser));
 
+        // 루틴별 스케줄 요일 맵
+        Map<UUID, Set<DayOfWeek>> scheduleByRoutine = buildScheduleMap(routines);
+
+
         // 모든 사용자 ID 수집
         List<UUID> allUserIds = users.stream()
                 .map(User::getId)
@@ -76,7 +80,7 @@ public class RoutineLogSeeder {
 
 
         List<RoutineSnapshot> savedSnapshots = createSnapshots(routines);
-        createLogsFromSnapshots(savedSnapshots, users, routineOwnerMap, usersWithOpenLog, openLogStartByUser);
+        createLogsFromSnapshots(savedSnapshots, users, routineOwnerMap, scheduleByRoutine, usersWithOpenLog, openLogStartByUser);
     }
 
 


### PR DESCRIPTION
## #️⃣ Issue Number

#110 

## 📝 요약(Summary)

### 인기순 정렬(POPULAR)
- 요일이 선택된 경우 → 해당 요일 루틴만 likeCount DESC, createdAt DESC 순으로 정렬
- 요일이 선택되지 않은 경우 → 전체 루틴을 인기순으로 정렬 (기존 로직 유지)

### 최신순 정렬(LATEST)
- 요일이 선택된 경우 → 해당 요일 루틴만 createdAt DESC 순으로 정렬
- 요일이 선택되지 않은 경우 → 전체 루틴을 최신순으로 정렬 (기존 로직 유지)

### Repository에 요일 필터 + 최신순/인기순 쿼리 메서드 추가
- findRoutinesByUserIdAndDayOfWeekOrderByPopularity(...)
- findRoutinesByUserIdAndDayOfWeekOrderByCreatedAtDesc(...)

### Service 계층에서 dayOfWeek 존재 여부에 따라 분기 처리



