### PR TITLE
Test/#130 dummy data

### DIFF
--- a/src/main/java/com/moru/backend/global/dummydata/seeder/RoutineLogSeeder.java
+++ b/src/main/java/com/moru/backend/global/dummydata/seeder/RoutineLogSeeder.java
@@ -204,6 +204,7 @@ public class RoutineLogSeeder {
             List<RoutineSnapshot> savedSnapshots,
             List<User> users,
             Map<UUID, User> routineOwnerMap,
+            Map<UUID, Set<DayOfWeek>> scheduleByRoutine,
             Set<UUID> usersWithOpenLog,
             Map<UUID, LocalDateTime> openLogStartByUser
     ) {
@@ -220,7 +221,9 @@ public class RoutineLogSeeder {
             User owner = routineOwnerMap.getOrDefault(
                     snapshot.getOriginalRoutineId(),
                     users.get(random.nextInt(users.size()))); // 혹시 못찾으면 랜덤 유저
-            logsToSave.add(buildRoutineLog(snapshot, owner, usersWithOpenLog, openLogStartByUser));
+
+            Set<DayOfWeek> scheduleDays = scheduleByRoutine.getOrDefault(snapshot.getOriginalRoutineId(), Set.of());
+            logsToSave.add(buildRoutineLog(snapshot, owner, scheduleDays, usersWithOpenLog, openLogStartByUser));
         }
         batchSaveLogs(logsToSave);
     }

--- a/src/main/java/com/moru/backend/global/dummydata/seeder/RoutineLogSeeder.java
+++ b/src/main/java/com/moru/backend/global/dummydata/seeder/RoutineLogSeeder.java
@@ -8,14 +8,14 @@ import com.moru.backend.domain.log.domain.snapshot.RoutineSnapshot;
 import com.moru.backend.domain.log.domain.snapshot.RoutineStepSnapshot;
 import com.moru.backend.domain.log.domain.snapshot.RoutineTagSnapshot;
 import com.moru.backend.domain.routine.domain.Routine;
+import com.moru.backend.domain.routine.domain.schedule.RoutineSchedule;
 import com.moru.backend.domain.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.Duration;
-import java.time.LocalDateTime;
+import java.time.*;
 import java.util.*;
 import java.util.stream.Collectors;
 

--- a/src/main/java/com/moru/backend/global/dummydata/seeder/RoutineLogSeeder.java
+++ b/src/main/java/com/moru/backend/global/dummydata/seeder/RoutineLogSeeder.java
@@ -54,6 +54,10 @@ public class RoutineLogSeeder {
         Map<UUID, User> routineOwnerMap = routines.stream()
                 .collect(Collectors.toMap(Routine::getId, Routine::getUser));
 
+        // 루틴별 스케줄 요일 맵
+        Map<UUID, Set<DayOfWeek>> scheduleByRoutine = buildScheduleMap(routines);
+
+
         // 모든 사용자 ID 수집
         List<UUID> allUserIds = users.stream()
                 .map(User::getId)
@@ -76,7 +80,7 @@ public class RoutineLogSeeder {
 
 
         List<RoutineSnapshot> savedSnapshots = createSnapshots(routines);
-        createLogsFromSnapshots(savedSnapshots, users, routineOwnerMap, usersWithOpenLog, openLogStartByUser);
+        createLogsFromSnapshots(savedSnapshots, users, routineOwnerMap, scheduleByRoutine, usersWithOpenLog, openLogStartByUser);
     }
 
 


### PR DESCRIPTION
## #️⃣ Issue Number

#130

## 📝 요약(Summary)

### 내용 요약
- 로그 startedAt이 이제 루틴의 스케줄 요일에만 생성되도록 변경.
- 라이프스타일 보정 기준을 now() 대신 로그 날짜의 실제 요일에 맞게 적용.
- 열린 로그가 있는 경우 → 다음 로그에서 강제 완료 처리 후 상태 해제.
- 완료 로그는 열린 로그보다 반드시 과거 스케줄 요일에 생성되도록 보정.

### 주요 변경사항
- buildScheduleMap 메서드 추가 (Routine → Map<UUID, Set<DayOfWeek>>).
- createLogsFromSnapshots에서 스케줄 정보를 buildRoutineLog로 전달.
- buildRoutineLog에서 스케줄 기반 날짜 선택 및 정합성 보정 로직 추가.
- pickRecentDateOnScheduledDay, pickScheduledDateBefore 보조 메서드 추가.

## 📸 스크린샷 (선택)



## 💬리뷰 요구사항(선택)



